### PR TITLE
Add flexible BucketStore

### DIFF
--- a/clamor/rest/http.py
+++ b/clamor/rest/http.py
@@ -71,7 +71,7 @@ class HTTP:
     def __init__(self, token: str, **kwargs):
         self._token = token
         self._session = kwargs.get('session', asks.Session())
-        self.rate_limiter = RateLimiter(InMemoryBucketStore())
+        self.rate_limiter = RateLimiter()
 
         self._responses = []
         self.headers = {

--- a/clamor/rest/http.py
+++ b/clamor/rest/http.py
@@ -12,7 +12,7 @@ from asks.response_objects import Response
 
 from ..exceptions import RequestFailed, Unauthorized, Forbidden, NotFound
 from ..meta import __url__ as clamor_url, __version__ as clamor_version
-from .rate_limit import Bucket, RateLimiter
+from .rate_limit import Bucket, RateLimiter, InMemoryBucketStore
 from .routes import APIRoute
 
 __all__ = (
@@ -71,7 +71,7 @@ class HTTP:
     def __init__(self, token: str, **kwargs):
         self._token = token
         self._session = kwargs.get('session', asks.Session())
-        self.rate_limiter = RateLimiter()
+        self.rate_limiter = RateLimiter(InMemoryBucketStore())
 
         self._responses = []
         self.headers = {

--- a/clamor/rest/http.py
+++ b/clamor/rest/http.py
@@ -47,6 +47,9 @@ class HTTP:
     app : str
         The application type for the ``Authorization`` header.
         Either ``Bot`` or ``Bearer``, defaults to ``Bot``.
+    bucket_store: :class:`~clamor.rest.rate_limit.BucketStore`
+        The bucket store which will be used by the RateLimiter.
+        If no bucket store is provided, the RateLimiter will store the buckets in memory.
 
     Attributes
     ----------
@@ -71,7 +74,7 @@ class HTTP:
     def __init__(self, token: str, **kwargs):
         self._token = token
         self._session = kwargs.get('session', asks.Session())
-        self.rate_limiter = RateLimiter()
+        self.rate_limiter = RateLimiter(kwargs.get('bucket_store'))
 
         self._responses = []
         self.headers = {

--- a/clamor/rest/rate_limit.py
+++ b/clamor/rest/rate_limit.py
@@ -225,8 +225,8 @@ class RateLimiter:
         Separate lock for global rate limits.
     """
 
-    def __init__(self):
-        self._buckets = InMemoryBucketStore()
+    def __init__(self, bucket_store=None):
+        self._buckets = bucket_store or InMemoryBucketStore()
         self.global_lock = anyio.create_lock()
 
     @asynccontextmanager

--- a/clamor/rest/rate_limit.py
+++ b/clamor/rest/rate_limit.py
@@ -10,6 +10,15 @@ import anyio
 from async_generator import async_generator, asynccontextmanager, yield_
 from asks.response_objects import Response
 
+import base4
+import json
+
+try:
+    import redis
+    INCLUDE_REDIS = True
+except ModuleNotFoundError:
+    INCLUDE_REDIS = False
+
 __all__ = (
     'Bucket',
     'CooldownBucket',
@@ -171,6 +180,36 @@ class InMemoryBucketStore(BucketStore):
 
     def has_bucket(self, bucket: Bucket) -> bool:
         return bucket in self._buckets
+
+
+if INCLUDE_REDIS:
+    class RedisBucketStore(BucketStore):
+        """A bucket store which stores the bucket in a redis database.
+
+        This class is only available if you have [redis-py](https://pypi.org/project/redis/)
+        installed.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Look at the [redis-py](https://pypi.org/project/redis/)
+            documentation to see all Keyowrd arguments
+        """
+
+        def __init__(self, **kwargs):
+            self.redis_client = redis.Redis(**kwargs)
+
+        def store_bucket(self, key: Bucket, value: CooldownBucket):
+            pass
+
+        def get_bucket(self, bucket: Bucket) -> CooldownBucket:
+            pass
+
+        def delete_bucket(self, bucket: Bucket):
+            pass
+
+        def has_bucket(self, bucket: Bucket) -> bool:
+            pass
 
 
 class RateLimiter:

--- a/clamor/rest/rate_limit.py
+++ b/clamor/rest/rate_limit.py
@@ -156,6 +156,7 @@ class InMemoryBucketStore(BucketStore):
     RateLimiter to store buckets.
 
     """
+
     def __init__(self):
         self._buckets = {}
 
@@ -181,7 +182,8 @@ class RateLimiter:
     can be used for that. It can also be used as an async
     contextmanager.
 
-    Buckets are stored in a dictionary as literal bucket and
+    Buckets are stored in the bucket store passed in the constructor.
+    If no bucket store is specified, the buckets are stored in memory.
     :class:`~clamor.rest.rate_limit.CooldownBucket` objects.
 
     .. code-block:: python3

--- a/clamor/rest/rate_limit.py
+++ b/clamor/rest/rate_limit.py
@@ -159,17 +159,17 @@ class InMemoryBucketStore(BucketStore):
     def __init__(self):
         self._buckets = {}
 
-    def store_bucket(bucket: Bucket):
-        pass
+    def store_bucket(self, key: Bucket, value: CooldownBucket):
+        self._buckets[key] = value
 
-    def get_bucket(bucket: Bucket) -> CooldownBucket:
-        pass
+    def get_bucket(self, bucket: Bucket) -> CooldownBucket:
+        return self._buckets[bucket]
 
-    def delete_bucket(bucket: Bucket):
-        pass
+    def delete_bucket(self, bucket: Bucket):
+        del self._buckets[bucket]
 
-    def has_bucket(bucket: Bucket) -> bool:
-        pass
+    def has_bucket(self, bucket: Bucket) -> bool:
+        return bucket in self._buckets
 
 
 class RateLimiter:

--- a/clamor/rest/rate_limit.py
+++ b/clamor/rest/rate_limit.py
@@ -225,8 +225,8 @@ class RateLimiter:
         Separate lock for global rate limits.
     """
 
-    def __init__(self):
-        self._buckets = {}
+    def __init__(self, bucket_store):
+        self._buckets = bucket_store or InMemoryBucketStore()
         self.global_lock = anyio.create_lock()
 
     @asynccontextmanager

--- a/clamor/rest/rate_limit.py
+++ b/clamor/rest/rate_limit.py
@@ -10,9 +10,6 @@ import anyio
 from async_generator import async_generator, asynccontextmanager, yield_
 from asks.response_objects import Response
 
-import base4
-import json
-
 try:
     import redis
     INCLUDE_REDIS = True
@@ -126,23 +123,22 @@ class BucketStore(abc.ABC):
     This class is used to store RateLimiting buckets.
     This makes it possible to store buckets in other ways.
     For example in Redis.
-
     """
 
     @abc.abstractmethod
-    def store_bucket(key: Bucket, value: CooldownBucket):
+    def store_bucket(self, key: Bucket, value: CooldownBucket):
         pass
 
     @abc.abstractmethod
-    def get_bucket(bucket: Bucket) -> CooldownBucket:
+    def get_bucket(self, bucket: Bucket) -> CooldownBucket:
         pass
 
     @abc.abstractmethod
-    def delete_bucket(bucket: Bucket):
+    def delete_bucket(self, bucket: Bucket):
         pass
 
     @abc.abstractmethod
-    def has_bucket(bucket: Bucket) -> bool:
+    def has_bucket(self, bucket: Bucket) -> bool:
         pass
 
     def __getitem__(self, bucket: Bucket) -> CooldownBucket:

--- a/clamor/rest/rate_limit.py
+++ b/clamor/rest/rate_limit.py
@@ -225,8 +225,8 @@ class RateLimiter:
         Separate lock for global rate limits.
     """
 
-    def __init__(self, bucket_store):
-        self._buckets = bucket_store or InMemoryBucketStore()
+    def __init__(self):
+        self._buckets = InMemoryBucketStore()
         self.global_lock = anyio.create_lock()
 
     @asynccontextmanager

--- a/clamor/rest/rate_limit.py
+++ b/clamor/rest/rate_limit.py
@@ -121,7 +121,7 @@ class BucketStore(abc.ABC):
     """
 
     @abc.abstractmethod
-    def store_bucket(bucket: Bucket):
+    def store_bucket(key: Bucket, value: CooldownBucket):
         pass
 
     @abc.abstractmethod
@@ -147,6 +147,29 @@ class BucketStore(abc.ABC):
 
     def __contains__(self, bucket: Bucket) -> bool:
         return self.has_bucket(bucket)
+
+
+class InMemoryBucketStore(BucketStore):
+    """A BucketStore which stores the bucket in-memory via a dict
+
+    This bucket store is the default store which will be used by the
+    RateLimiter to store buckets.
+
+    """
+    def __init__(self):
+        self._buckets = {}
+
+    def store_bucket(bucket: Bucket):
+        pass
+
+    def get_bucket(bucket: Bucket) -> CooldownBucket:
+        pass
+
+    def delete_bucket(bucket: Bucket):
+        pass
+
+    def has_bucket(bucket: Bucket) -> bool:
+        pass
 
 
 class RateLimiter:


### PR DESCRIPTION
# Pull Request Template

Please try to complete the below as best as possible. Some of the fields
may not be necessary so feel free to add or edit as you see fit.

## Checklist

- [x] There is an existing issue report for this PR.
- [ ] I have forked this project.
- [x] I have created a feature branch.
- [x] My changes have been committed.
- [ ] I have pushed my changes to the branch.

## Title

Custom BucketStore

## Description

Some larger bots may not want to store the RateLimit buckets in memory, but in [Redis](https://redis.io), for example.
This pull request makes this possible.

## Issue Resolution

This Pull Request fixes #2 

## New or Changed Features

* [x] Add BucketStore class with all required methods
* [x] Provide default in-memory implementation
* [x] Give the User the possibility to inject his own implementation into the RateLimiter
